### PR TITLE
Made generating beta changelogs easier

### DIFF
--- a/hassrelease/changelog.py
+++ b/hassrelease/changelog.py
@@ -97,7 +97,8 @@ def generate(release, prs):
         pr = prs.get(line.pr)
 
         if (pr.milestone is not None and
-                StrictVersion(pr.milestone.title) != release.version):
+            StrictVersion(pr.milestone.title).version !=
+                release.version.version):  # Ignore beta version tag
             continue
 
         labels = [label.name for label in pr.labels()]

--- a/hassrelease/model.py
+++ b/hassrelease/model.py
@@ -38,21 +38,20 @@ class PRCache:
 
 
 class Release:
-    def __init__(self, version, *, branch=None):
+    def __init__(self, version, *, branch):
         self.version = StrictVersion(version)
-        self.version_raw = version
+        self.branch = branch
         self._log_lines = None
 
-        if self.version.version[-1] == 0:
-            self.identifier = 'release-{}-{}'.format(*self.version.version[:2])
+        if self.version.version[-1] == 0 and not self.version.prerelease:
+            vstring = '-'.join(map(str, self.version.version[:2]))
         else:
-            self.identifier = 'release-{}-{}-{}'.format(*self.version.version)
+            vstring = '-'.join(map(str, self.version.version))
+        self.identifier = 'release-' + vstring
 
-
-        if branch is not None:
-            self.branch = branch
-        elif self.version.version[-1] == 0:
-            self.branch =  self.identifier
+        if self.version.prerelease:
+            pstring = ''.join(map(str, self.version.prerelease))
+            self.identifier = self.identifier + pstring
 
     def log_lines(self):
         if self._log_lines is None:


### PR DESCRIPTION
Some additional changes
* Assign branch directly since it is set to `rc` by default and therefore won't be `None`
* `release_notes 0.68.0b1` is now possible. The version comparison between the milestone on the release ignores the prerelease.
* beta release branches now generate own file `release-0-68-0b1.md`. The mapping is as follows:
   - `0.68` and `0.68.0` -> `release-0-68` (same as before)
   - `0.68.0b1` -> `release-0-68-0b1`
   - `0.68.1` -> `release-0-68-1` (same as before)
   - `0.68.1b1` -> `release-0-68-1b1`