### PR TITLE
Limit beta fix to 0-release

### DIFF
--- a/hassrelease/changelog.py
+++ b/hassrelease/changelog.py
@@ -101,7 +101,9 @@ def generate(release, prs, *, website_tags):
     label_groups['new-platform'] = []
     label_groups['new-feature'] = []
     label_groups['breaking change'] = []
-    label_groups['cherry-picked'] = []
+    if release.version.version[-1] == 0:
+        # Only add 'beta fix' for 0-release
+        label_groups['cherry-picked'] = []
 
     changes = []
     links = set()


### PR DESCRIPTION
Only add the `beta fix` label group in case the release is a `0-release`, eg. `0.68.0`.