### PR TITLE
print link to PR when creating release notes

### DIFF
--- a/hassrelease/commands.py
+++ b/hassrelease/commands.py
@@ -25,6 +25,10 @@ def release_notes(branch, force_update, release):
         release = git.get_hass_version(branch)
         print("Auto detected version", release)
 
+    print(
+        f"PR link: https://github.com/home-assistant/home-assistant/compare/master...{branch}?expand=1&title={release}"
+    )
+
     rel = model.Release(release, branch=branch)
     file_website = "data/{}.md".format(rel.identifier)
     file_github = "data/{}-github.md".format(rel.identifier)


### PR DESCRIPTION
Print url to make the PR for the release when generating release notes and swap generating GitHub and website notes.

```
$ hr release_notes
Auto detected version 0.104.2
PR link: https://github.com/home-assistant/home-assistant/compare/master...rc?expand=1&title=0.104.2
Press enter to copy GitHub changelog to clipboard
Press enter to copy website changelog to clipboard
```

