### PR TITLE
Fix extracting hass version

### DIFF
--- a/hassrelease/git.py
+++ b/hassrelease/git.py
@@ -1,3 +1,4 @@
+import configparser
 import subprocess
 
 from .core import HassReleaseError
@@ -6,7 +7,7 @@ from .core import HassReleaseError
 def get_hass_version(branch):
     """Get the HA version of a branch."""
     process = subprocess.run(
-        "git show {branch}:homeassistant/const.py".format(branch=branch),
+        "git show {branch}:setup.cfg".format(branch=branch),
         shell=True,
         cwd="../core",
         stdout=subprocess.PIPE,
@@ -20,9 +21,9 @@ def get_hass_version(branch):
         )
         raise HassReleaseError(text)
 
-    locals = {}
-    exec(process.stdout, {}, locals)
-    return locals["__version__"]
+    config = configparser.ConfigParser()
+    config.read_string(process.stdout.decode())
+    return config['metadata']['version']
 
 
 def get_log(branch):

--- a/hassrelease/git.py
+++ b/hassrelease/git.py
@@ -23,7 +23,7 @@ def get_hass_version(branch):
 
     config = configparser.ConfigParser()
     config.read_string(process.stdout.decode())
-    return config['metadata']['version']
+    return config["metadata"]["version"]
 
 
 def get_log(branch):


### PR DESCRIPTION
It used to execute `const.py`, but that's no longer a standalone file now that it relies on a backport of `StrEnum`. Luckily we just added `setup.cfg`.