### PR TITLE
Fix credits.py for anonymous user without e-mail

### DIFF
--- a/hassrelease/credits.py
+++ b/hassrelease/credits.py
@@ -146,7 +146,8 @@ class ContributorsPageTask(RequestTask):
                     "contributions"
                 ]
             # contr['type'] == 'Anonymous'
-            else:
+            # Anonymous contributions might not have an email
+            elif "email" in contr:
                 login = login_by_email.get(contr["email"])
                 if login is None:
                     # We could just get the login right from the email


### PR DESCRIPTION
I noticed the `credits.py` script reported quite a lot of errors.
It turns out that the contributors API might return anonymous contributors without an e-mail.
This PR fixes this.

Proof PR: https://github.com/home-assistant/home-assistant.io/pull/22748