### PR TITLE
Fix black

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
 flake8==3.7.9
-black==19.10b0
+black==22.3.0
 pytest==5.4.3


### PR DESCRIPTION
The tests on the 2 open PRs are not passing due to the `black` version used not being compatible with the latest `click` version.

`black 22.3.0` fixes this issue.

Once this PR is merged, we can rebase the two other PRs.