### PR TITLE
Work arround for names containing commas

### DIFF
--- a/hassrelease/credits.py
+++ b/hassrelease/credits.py
@@ -285,6 +285,8 @@ def generate_credits(num_simul_requests, no_cache, quiet):
             for lin in inp:
                 if "," not in lin:
                     lin = lin.strip() + ","
+                if lin.count(',') > 1:
+                    lin = ''.join(lin.rsplit(',', 1))
                 key, value = [val.strip() for val in lin.split(",")]
                 data[key] = value
         return data


### PR DESCRIPTION
This avoid exeption when there is a comma in the name