### PR TITLE
credits.py: Swap orga for org

### DIFF
--- a/hassrelease/credits.py
+++ b/hassrelease/credits.py
@@ -362,7 +362,7 @@ def generate_credits(num_simul_requests, no_cache, quiet):
                 num_contribs, "commits" if num_contribs > 1 else "commit", repo_name
             )
             user_total_contribs += num_contribs
-        count_string = "{} total commits to the Home Assistant orga:\n{}".format(
+        count_string = "{} total commits to the Home Assistant org:\n{}".format(
             user_total_contribs, count_string
         )
         # TODO if the login_by_email file contains some users that


### PR DESCRIPTION
I'm guessing it's still an abbreviation of organisation, but not a common one...