### PR TITLE
Add devcontainer, compatibility with Python 3.13, fix pylint issues

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+  "name": "hass-release",
+  "context": "..",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.13",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "charliermarsh.ruff",
+        "ms-python.pylint",
+        "ms-python.vscode-pylance"
+      ],
+      "editor.formatOnPaste": false,
+      "editor.formatOnSave": true,
+      "editor.formatOnType": true,
+      "files.trimTrailingWhitespace": true,
+      "terminal.integrated.profiles.linux": {
+        "zsh": {
+          "path": "/usr/bin/zsh"
+        }
+      },
+      "terminal.integrated.defaultProfile.linux": "zsh",
+      "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff"
+      }
+    }
+  },
+  "postCreateCommand": "script/setup && pip install -e .",
+  "remoteUser": "vscode"
+}

--- a/hassrelease/changelog.py
+++ b/hassrelease/changelog.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from datetime import datetime
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 INFO_TEMPLATE = "([@{0}] - [#{1}])"
 PR_TEMPLATE = "([#{0}])"
@@ -40,11 +40,11 @@ def automation_link(platform, website_tags):
         val = platform[len("automation.") :]
 
     if website_tags:
-        format = "[{} docs]: /docs/automation/trigger/#{}-trigger"
+        template = "[{} docs]: /docs/automation/trigger/#{}-trigger"
     else:
-        format = "[{} docs]: https://www.home-assistant.io/docs/automation/trigger/#{}-trigger"
+        template = "[{} docs]: https://www.home-assistant.io/docs/automation/trigger/#{}-trigger"
 
-    return format.format(platform, val)
+    return template.format(platform, val)
 
 
 LABEL_MAP = {
@@ -95,7 +95,7 @@ def generate(release, prs, *, website_tags):
     label_groups["new-integration"] = []
     label_groups["new-platform"] = []
     label_groups["breaking-change"] = []
-    if release.version.version[-1] == 0:
+    if release.version.release[-1] == 0:
         # Only add 'beta fix' for 0-release
         label_groups["cherry-picked"] = []
 
@@ -112,7 +112,7 @@ def generate(release, prs, *, website_tags):
 
         if (
             pr.milestone is not None
-            and StrictVersion(pr.milestone.title).version != release.version.version
+            and Version(pr.milestone.title).release != release.version.release
         ):  # Ignore beta version tag
             continue
 
@@ -135,7 +135,7 @@ def generate(release, prs, *, website_tags):
                 if label == "cherry-picked":
                     parts.append("(beta fix)")
                 else:
-                    parts.append("({})".format(label))
+                    parts.append(f"({label})")
 
         msg = " ".join(parts)
         changes.append(msg)

--- a/hassrelease/github.py
+++ b/hassrelease/github.py
@@ -1,6 +1,6 @@
 import os
 import time
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 import requests
 from github3 import GitHub
@@ -14,7 +14,7 @@ def get_session():
     """Fetch and/or load API authorization token for GitHub."""
     token = None
     if os.path.isfile(TOKEN_FILE):
-        with open(TOKEN_FILE) as fd:
+        with open(TOKEN_FILE, encoding="utf-8") as fd:
             token = fd.readline().strip()
     elif "GITHUB_TOKEN" in os.environ:
         token = os.environ["GITHUB_TOKEN"]
@@ -52,7 +52,7 @@ def get_latest_version_milestone(repo):
 
     for ms in repo.milestones(state="open"):
         try:
-            milestones.append((StrictVersion(ms.title), ms))
+            milestones.append((Version(ms.title), ms))
         except ValueError:
             print("Found milestone with invalid version", ms.title)
 

--- a/hassrelease/model.py
+++ b/hassrelease/model.py
@@ -1,5 +1,5 @@
 import re
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 from .git import get_log
 
@@ -38,18 +38,18 @@ class PRCache:
 
 class Release:
     def __init__(self, version, *, branch):
-        self.version = StrictVersion(version)
+        self.version = Version(version)
         self.branch = branch
         self._log_lines = None
 
-        if self.version.version[-1] == 0 and not self.version.prerelease:
-            vstring = "-".join(map(str, self.version.version[:2]))
+        if self.version.release[-1] == 0 and not self.version.is_prerelease:
+            vstring = "-".join(map(str, self.version.release[:2]))
         else:
-            vstring = "-".join(map(str, self.version.version))
+            vstring = "-".join(map(str, self.version.release))
         self.identifier = "release-" + vstring
 
-        if self.version.prerelease:
-            pstring = "".join(map(str, self.version.prerelease))
+        if self.version.is_prerelease:
+            pstring = "".join(map(str, self.version.pre))
             self.identifier = self.identifier + pstring
 
     @property
@@ -58,7 +58,7 @@ class Release:
 
         Patch release is when X in 0.0.X is not 0.
         """
-        return self.version.version[-1] != 0
+        return self.version.release[-1] != 0
 
     def log_lines(self):
         if self._log_lines is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 click
-github3.py==1.2.0
+github3.py>=4.0.1
+packaging
 pystache
 requests
 toml

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,6 @@ setup(
     name="hassrelease",
     version="1.0",
     packages=["hassrelease"],
-    install_requires=["github3.py==3.2.0", "click", "pystache", "requests", "toml"],
+    install_requires=["github3.py>=4.0.1", "click", "pystache", "requests", "toml", "packaging"],
     entry_points={"console_scripts": ["hassrelease = hassrelease.__main__:main"]},
 )


### PR DESCRIPTION
I found it very difficult to get this repository up and running. This PR helps make it easy to get started:
- adds a devcontainer which is based closely off Home Assistant core
- fixes compatibility with Python 3.13, e.g. [removal of distutils](https://docs.python.org/3/library/distutils.html)
- fixes a few minor pylint errors thrown up by the extension recommended for Home Assistant core