### PR TITLE
Update black version

### DIFF
--- a/hassrelease/__main__.py
+++ b/hassrelease/__main__.py
@@ -1,4 +1,5 @@
 """Main part of the Home Assistant Release helper."""
+
 import click
 
 from .commands import cli

--- a/hassrelease/const.py
+++ b/hassrelease/const.py
@@ -1,4 +1,5 @@
 """Constants for the Home Assistant release helper tool."""
+
 TOKEN_FILE = ".token"
 # TODO replace with a single file with 3 columns?
 LOGIN_BY_EMAIL_FILE = "data/login_by_email.csv"

--- a/hassrelease/credits.py
+++ b/hassrelease/credits.py
@@ -1,4 +1,5 @@
 """Create the credits page for home-assistant.io."""
+
 import re
 import sys
 import threading
@@ -285,8 +286,8 @@ def generate_credits(num_simul_requests, no_cache, quiet):
             for lin in inp:
                 if "," not in lin:
                     lin = lin.strip() + ","
-                if lin.count(',') > 1:
-                    lin = ''.join(lin.rsplit(',', 1))
+                if lin.count(",") > 1:
+                    lin = "".join(lin.rsplit(",", 1))
                 key, value = [val.strip() for val in lin.split(",")]
                 data[key] = value
         return data

--- a/hassrelease/repo_core.py
+++ b/hassrelease/repo_core.py
@@ -1,4 +1,5 @@
 """Helper for the Home Assistant repository."""
+
 from pathlib import Path
 import json
 import subprocess

--- a/hassrelease/repo_frontend.py
+++ b/hassrelease/repo_frontend.py
@@ -1,4 +1,5 @@
 """Helper for the Home Assistant frontend repository."""
+
 import os
 
 PATH = os.path.join(os.path.dirname(__file__), "../../frontend/")

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
 flake8==3.7.9
-black==22.3.0
+black==24.4.2
 pytest==5.4.3


### PR DESCRIPTION
The currently used black version has a known
security issue documented in CVE-2024-21503 that
could cause denial of service on pull requests.

See https://github.com/home-assistant/hass-release/security/dependabot/1