### PR TITLE
Add packaging for Python 3.12 compat

### DIFF
--- a/hassrelease/changelog.py
+++ b/hassrelease/changelog.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from datetime import datetime
-from distutils.version import StrictVersion
+from packaging.version import StrictVersion
 
 INFO_TEMPLATE = "([@{0}] - [#{1}])"
 PR_TEMPLATE = "([#{0}])"

--- a/hassrelease/github.py
+++ b/hassrelease/github.py
@@ -1,6 +1,6 @@
 import os
 import time
-from distutils.version import StrictVersion
+from packaging.version import StrictVersion
 
 import requests
 from github3 import GitHub

--- a/hassrelease/model.py
+++ b/hassrelease/model.py
@@ -1,5 +1,5 @@
 import re
-from distutils.version import StrictVersion
+from packaging.version import StrictVersion
 
 from .git import get_log
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,6 @@ setup(
     name="hassrelease",
     version="1.0",
     packages=["hassrelease"],
-    install_requires=["github3.py==3.2.0", "click", "pystache", "requests", "toml"],
+    install_requires=["github3.py==3.2.0", "click", "pystache", "requests", "toml", "packaging"],
     entry_points={"console_scripts": ["hassrelease = hassrelease.__main__:main"]},
 )


### PR DESCRIPTION
Add `packaging` to required packages as it got removed in Python 3.12+