### PR TITLE
Changelog: remove zero padding in generated release version

### DIFF
--- a/hassrelease/model.py
+++ b/hassrelease/model.py
@@ -60,6 +60,36 @@ class Release:
         """
         return self.version.release[-1] != 0
 
+    @property
+    def blog_slug(self):
+        """Return blog slug without zero-padding.
+        
+        Example: For version 2026.4.0, returns 'release-20264'
+        """
+        if self.version.release[-1] == 0 and not self.version.is_prerelease:
+            # Major release: join year and month without separator
+            return f"release-{self.version.release[0]}{self.version.release[1]}"
+        else:
+            # Patch release: join all parts without separator
+            return "release-" + "".join(map(str, self.version.release))
+
+    @property
+    def blog_year(self):
+        """Return the year for blog URL (first part of version)."""
+        return self.version.release[0]
+
+    @property
+    def blog_month(self):
+        """Return the month for blog URL without zero-padding (second part of version)."""
+        return self.version.release[1]
+
+    @property
+    def blog_day(self):
+        """Return the day for blog URL without zero-padding (third part of version for patches, 1 for major releases)."""
+        if self.is_patch_release:
+            return self.version.release[2]
+        return 1
+
     def log_lines(self):
         if self._log_lines is None:
             self._log_lines = [LogLine(line) for line in get_log(self.branch)]

--- a/hassrelease/model.py
+++ b/hassrelease/model.py
@@ -63,7 +63,7 @@ class Release:
     @property
     def blog_slug(self):
         """Return blog slug without zero-padding.
-        
+
         Example: For version 2026.4.0, returns 'release-20264'
         """
         if self.version.release[-1] == 0 and not self.version.is_prerelease:
@@ -80,12 +80,18 @@ class Release:
 
     @property
     def blog_month(self):
-        """Return the month for blog URL without zero-padding (second part of version)."""
+        """Return the month for blog URL without zero-padding.
+
+        Second part of version.
+        """
         return self.version.release[1]
 
     @property
     def blog_day(self):
-        """Return the day for blog URL without zero-padding (third part of version for patches, 1 for major releases)."""
+        """Return the day for blog URL without zero-padding.
+
+        Third part of version for patches, 1 for major releases.
+        """
         if self.is_patch_release:
             return self.version.release[2]
         return 1

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -20,3 +20,37 @@ def test_logline_with_pr():
 def test_release_branch():
     release = Release("0.40.1", branch="rc")
     assert release.identifier == "release-0-40-1"
+
+
+def test_blog_slug_major_release():
+    """Test blog_slug for major releases without zero-padding."""
+    release = Release("2026.4.0", branch="rc")
+    assert release.blog_slug == "release-20264"
+    
+    release2 = Release("2026.12.0", branch="rc")
+    assert release2.blog_slug == "release-202612"
+
+
+def test_blog_slug_patch_release():
+    """Test blog_slug for patch releases."""
+    release = Release("2026.4.1", branch="rc")
+    assert release.blog_slug == "release-202641"
+    
+    release2 = Release("2026.12.3", branch="rc")
+    assert release2.blog_slug == "release-2026123"
+
+
+def test_blog_date_components_major_release():
+    """Test blog date components for major releases."""
+    release = Release("2026.4.0", branch="rc")
+    assert release.blog_year == 2026
+    assert release.blog_month == 4
+    assert release.blog_day == 1  # Default to 1 for major releases
+
+
+def test_blog_date_components_patch_release():
+    """Test blog date components for patch releases."""
+    release = Release("2026.12.3", branch="rc")
+    assert release.blog_year == 2026
+    assert release.blog_month == 12
+    assert release.blog_day == 3


### PR DESCRIPTION
In the generated changelog (https://www.home-assistant.io/changelogs/core-2026.4), the link to the release notes contains a zero padding, but the actual address does not have zero padding. This results in a broken link.

<img width="663" height="107" alt="image" src="https://github.com/user-attachments/assets/6e40eb3e-e8ba-4c16-a422-ab0a52209023" />

This PR removes the zero padding in those generated link

related to: https://github.com/home-assistant/home-assistant.io/pull/44612, which fixes the link for existing posts